### PR TITLE
Revert "Fullscreen mode with toggle, auto screen res"

### DIFF
--- a/data/prepare.py
+++ b/data/prepare.py
@@ -9,19 +9,15 @@ import pygame as pg
 from . import tools
 
 
+SCREEN_SIZE = (800, 600)
 ORIGINAL_CAPTION = "Towers v 1.0"
 
 
 # Initialization
 pg.init()
 os.environ['SDL_VIDEO_CENTERED'] = "TRUE"
-pg.display.set_caption(ORIGINAL_CAPTION) 
-DISPLAYINFO = pg.display.Info()
-WINDOWWIDTH = DISPLAYINFO.current_w
-WINDOWHEIGHT = DISPLAYINFO.current_h
-SCREEN_SIZE = (WINDOWWIDTH, WINDOWHEIGHT)
-SCREEN = pg.display.set_mode(SCREEN_SIZE, 0)
-FLAGS = SCREEN.get_flags()
+pg.display.set_caption(ORIGINAL_CAPTION)
+SCREEN = pg.display.set_mode(SCREEN_SIZE)
 SCREEN_RECT = SCREEN.get_rect()
 
 if getattr(sys, 'frozen', False):

--- a/data/states/game.py
+++ b/data/states/game.py
@@ -236,13 +236,6 @@ class Game(tools._State):
                     self.pause()
                 elif self.phase == 'pause':
                     self.unpause()
-            elif event.key == pg.K_f:
-                if prepare.FLAGS&pg.FULLSCREEN == False:
-                    prepare.FLAGS|=pg.FULLSCREEN|pg.DOUBLEBUF
-                    pg.display.set_mode(prepare.SCREEN_SIZE, prepare.FLAGS, 0)
-                else:
-                    prepare.FLAGS^=pg.FULLSCREEN|pg.DOUBLEBUF
-                    pg.display.set_mode(prepare.SCREEN_SIZE, prepare.FLAGS, 0)
         elif event.type == pg.MOUSEBUTTONUP:
             if self.phase == 'game':
                 self.click(event.pos)

--- a/readme.txt
+++ b/readme.txt
@@ -1,3 +1,3 @@
-Tower-defense game. Build towers, shoot monsters, that kind of stuff. Works on Python 2 (>= 2.6.x) and Python 3 with Pygame.
+Tower-defense game. Build towers, shoot monsters, that kind of stuff. Works on Python 2 and Python 3 with Pygame.
 
 setup.py is cx_Freeze's file.


### PR DESCRIPTION
Reverts Cactusson/towers#1

Reason: full screen mode doesn't really work in this game, because all the sizes of GUI/objects/etc are set to actual numbers, not some values based on the screen size.
